### PR TITLE
removed postinstall step from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-password-toggle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Easily show and hide password via a toggle button.",
   "directories": {
     "doc": "doc",
@@ -9,8 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test",
-    "postinstall": "bower install"
+    "test": "ember test"
   },
   "repository": "",
   "engines": {


### PR DESCRIPTION
I found installing this forced a "bower install" and as a consumer it seemed to be a problem. Could you pull this in/ publish this to npm as 0.1.2 :)