### PR TITLE
change the plugin to automatically disable autocomplete, autocorrect,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Optionally you set:
   - inputClass
  - inputId
  - focus=true
- - autocomplete
 
 ```hbs
-{{password-toggle password=model.password inputId="input-id" wrapperClass="outerDivClass" buttonClass="buttonCustomClass" inputClass="inputCustomClass" focus=true autocomplete="autocomplete"}}
+{{password-toggle password=model.password inputId="input-id" wrapperClass="outerDivClass" buttonClass="buttonCustomClass" inputClass="inputCustomClass" focus=true}}
 ```
+
+## Migrating from Version 1.x to 2.x
+
+In order to prevent browsers from storing passwords when 'SHOW' is toggled, the plugin has been changed to automatically set the autocomplete value to 'off' when displaying the password in the clear.
 
 ## Running the unit tests
 ```sh

--- a/addon/components/password-toggle.js
+++ b/addon/components/password-toggle.js
@@ -10,9 +10,17 @@ export default Ember.Component.extend({
 
             if (text === 'Show') {
                 $(this).text('Hide');
+                $input.attr('autocomplete', 'off');
+                $input.attr('autocorrect', 'off');
+                $input.attr('spellcheck', 'off');
+                $input.attr('autocapitalize', 'off');
                 $input.attr('type', 'text');
             } else if (text === 'Hide') {
                 $(this).text('Show');
+                $input.removeAttr('autocomplete');
+                $input.removeAttr('autocorrect');
+                $input.removeAttr('spellcheck');
+                $input.removeAttr('autocapitalize');
                 $input.attr('type', 'password');
             }
         });

--- a/tests/acceptance/acceptance-test.js
+++ b/tests/acceptance/acceptance-test.js
@@ -53,12 +53,20 @@ test('password-toggle test', function(assert) {
     andThen(function(){
         assert.equal(find(PASSWORD_BUTTON_ONE).text(), 'Hide');
         assert.equal(find(PASSWORD_INPUT_ONE).attr('type'), 'text');
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocomplete'), 'off');
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocorrect'), 'off');
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('spellcheck'), 'off');
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocapitalize'), 'off');
     });
 
     click(PASSWORD_BUTTON_ONE);
     andThen(function(){
         assert.equal(find(PASSWORD_BUTTON_ONE).text(), 'Show');
         assert.equal(find(PASSWORD_INPUT_ONE).attr('type'), 'password');
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocomplete'), undefined);
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocorrect'), undefined);
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('spellcheck'), undefined);
+        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocapitalize'), undefined);
     });
 });
 
@@ -78,19 +86,11 @@ test('password-toggle allows custom tabindex to be passed in', function(assert) 
     });
 });
 
-test('xxx password-toggle allows custom maxlength to be passed in', function(assert) {
+test('password-toggle allows custom maxlength to be passed in', function(assert) {
     visit('/');
     andThen(function() {
         assert.equal(find(PASSWORD_INPUT_TWO).attr('maxlength'), 10);
         assert.equal(find(PASSWORD_INPUT_ONE).attr('maxlength'), undefined);
-    });
-});
-
-test('password-toggle allows custom autocomplete to be passed in', function(assert) {
-    visit('/');
-    andThen(function() {
-        assert.equal(find(PASSWORD_INPUT_ONE).attr('autocomplete'), 'new-password');
-        assert.equal(find(PASSWORD_INPUT_TWO).attr('autocomplete'), undefined);
     });
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <h2 id="title">Welcome to Ember.js</h2>
-{{password-toggle password=model.password wrapperClass="wrapperPassword1" buttonClass="buttonPassword1" inputClass="text-input password1" focus=true autocomplete="new-password"}}
+{{password-toggle password=model.password wrapperClass="wrapperPassword1" buttonClass="buttonPassword1" inputClass="text-input password1" focus=true}}
 {{password-toggle tabindex=3 inputId="password" maxlength=10 password=model.confirmPassword wrapperClass="wrapperPassword2" buttonClass="buttonPassword2" inputClass="text-input confirm-password2"}}
 {{password-toggle inputId="passwordWithAction" password=model.anything wrapperClass="wrapperPassword2" buttonClass="buttonPassword2" action="triggerAction" inputClass="text-input confirm-password3"}}
 


### PR DESCRIPTION
… spellcheck, and autocapitalize when the "SHOW" is toggled

My first pass at fixing  #23 makes the plugin more opinionated in order to prevent people from screwing up autocomplete, which is remarkably easy to do. 