### PR TITLE
Allow undefined action, fixes #32

### DIFF
--- a/addon/components/password-toggle.js
+++ b/addon/components/password-toggle.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { get, computed } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 import { warn } from '@ember/debug';
 import Component from '@ember/component';
 
@@ -37,7 +38,7 @@ export default Component.extend({
         warn('The ember-cli-password-toggle `action` should be a closure action', false, { id: 'ember-cli-password-toggle.action-type' });
         this.sendAction('action');
         /* eslint-enable */
-      } else {
+      } else if (!isEmpty(actionToBubble)) {
         actionToBubble();
       }
     }

--- a/tests/integration/action-test.js
+++ b/tests/integration/action-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, triggerEvent } from '@ember/test-helpers';
+
+module('integration: action test', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('model', {password: null});
+  });
+
+  test('closure actions are supported in addition to legacy ember actions', async function(assert) {
+    assert.expect(1);
+
+    this.set('foobar', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`{{password-toggle password=model.password action=(action foobar)}}`);
+
+    await triggerEvent('button', 'keypress', { keyCode: 13 });
+  });
+
+  test('ember-cli-password-toggle can be used without defining an action', async function(assert) {
+    await render(hbs`{{password-toggle password=model.password}}`);
+
+    await triggerEvent('button', 'keypress', { keyCode: 13 });
+
+    assert.ok(true, 'There was no assertion if no action was defined');
+  });
+});

--- a/tests/integration/placeholder-test.js
+++ b/tests/integration/placeholder-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll, triggerEvent } from '@ember/test-helpers';
+import { render, find, findAll } from '@ember/test-helpers';
 
 module('integration: placeholder test', function(hooks) {
   setupRenderingTest(hooks);
@@ -22,17 +22,5 @@ module('integration: placeholder test', function(hooks) {
     const selector = 'input.ember-password-toggle-input';
     assert.equal(findAll(selector).length, 1);
     assert.equal(find(selector).getAttribute('placeholder'), undefined);
-  });
-
-  test('closure actions are supported in addition to legacy ember actions', async function(assert) {
-    assert.expect(1);
-
-    this.set('foobar', () => {
-      assert.ok(true);
-    });
-
-    await render(hbs`{{password-toggle password=model.password action=(action foobar)}}`);
-
-    await triggerEvent('button', 'keypress', { keyCode: 13 });
   });
 });


### PR DESCRIPTION
In some use-cases, you want to handle the sending of the form yourself and don't need an action to be set. If done so, the password-toggle component currently throws an error, as it wants to execute an undefined function. In this PR I introduce a check if action is defined.